### PR TITLE
feat: Add bundles and allow for basic FastAPI session interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,22 @@ The `devleaps-policy-client cursor` command will forward hook events to the poli
 
 </details>
 
+## Sessions
+
+Each Claude Code or Cursor session receives a unique `session_id`. Policies can use this to track context across multiple hook events within the same session, enabling stateful policy decisions. See the [session state utility](devleaps/policies/server/session/state.py) to store and retrieve per-session data.
+
+## Policy Bundles
+
+Policies can be organized into bundles to group related rules for specific workflows or project types. This allows you to compose different policy sets without having to manage separate server configurations.
+
+**How bundles work:**
+- Universal policies (registered with `bundle=None`) are always enforced
+- Bundle-specific policies are only enforced when enabled via `--bundle` flag
+- Multiple bundles can be enabled simultaneously: `devleaps-policy-client --bundle uv claude-code`
+- Bundles can coordinate through shared session state
+
+See the [uv example](devleaps/policies/example/main.py) for a working one-rule bundle implementation.
+
 ## Development
 
 This project is built with [uv](https://docs.astral.sh/uv/).

--- a/src/devleaps/policies/server/claude_code/api/pre_tool_use.py
+++ b/src/devleaps/policies/server/claude_code/api/pre_tool_use.py
@@ -1,6 +1,6 @@
-from typing import Any, Callable, Literal, Optional, Union
+from typing import Any, Callable, List, Literal, Optional, Union
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from .enums import PermissionDecision, ToolName
 from .output_base import BaseHookOutput

--- a/src/devleaps/policies/server/claude_code/api/request_wrapper.py
+++ b/src/devleaps/policies/server/claude_code/api/request_wrapper.py
@@ -1,0 +1,10 @@
+"""Generic request wrapper for bundle-aware hook processing."""
+from typing import Any, Dict, List
+
+from pydantic import BaseModel
+
+
+class RequestWrapper(BaseModel):
+    """Wrapper for hook requests that includes bundle filtering."""
+    bundles: List[str]
+    event: Dict[str, Any]

--- a/src/devleaps/policies/server/claude_code/routes.py
+++ b/src/devleaps/policies/server/claude_code/routes.py
@@ -13,6 +13,7 @@ from .api.pre_tool_use import (
     PreToolUseInput,
     PreToolUseOutput,
 )
+from .api.request_wrapper import RequestWrapper
 from .api.session_end import SessionEndInput, SessionEndOutput
 from .api.session_start import (
     SessionStartHookSpecificOutput,
@@ -64,20 +65,24 @@ def _log_generic_hook_outcome(hook_name: str, input_data, result):
 
 
 @router.post("/PreToolUse", response_model=PreToolUseOutput, response_model_exclude_none=True)
-async def pre_tool_use_hook(input_data: PreToolUseInput) -> PreToolUseOutput:
+async def pre_tool_use_hook(wrapper: RequestWrapper) -> PreToolUseOutput:
     """Handle PreToolUse hook events."""
+    input_data = PreToolUseInput(**wrapper.event)
+    bundles = wrapper.bundles
+
     logger.debug(
         "PreToolUse hook received",
         extra={
             "hook": "PreToolUse",
             "session_id": input_data.session_id,
             "tool_name": input_data.tool_name.value if hasattr(input_data.tool_name, 'value') else str(input_data.tool_name),
+            "bundles": bundles,
         }
     )
 
     generic_input = mapper.map_pre_tool_use_input(input_data)
 
-    results = execute_handlers_generic(generic_input)
+    results = execute_handlers_generic(generic_input, bundles)
 
     # Default to ASK for Bash and WebFetch
     if input_data.tool_name in [ToolName.BASH, ToolName.WEB_FETCH]:
@@ -98,13 +103,16 @@ async def pre_tool_use_hook(input_data: PreToolUseInput) -> PreToolUseOutput:
 
 
 @router.post("/PostToolUse", response_model=PostToolUseOutput, response_model_exclude_none=True)
-async def post_tool_use_hook(input_data: PostToolUseInput) -> PostToolUseOutput:
+async def post_tool_use_hook(wrapper: RequestWrapper) -> PostToolUseOutput:
     """Handle PostToolUse hook events."""
+    input_data = PostToolUseInput(**wrapper.event)
+    bundles = wrapper.bundles
+
     logger.info(f"PostToolUse hook: {input_data.tool_name} in session {input_data.session_id}")
 
     generic_input = mapper.map_post_tool_use_input(input_data)
 
-    results = execute_handlers_generic(generic_input)
+    results = execute_handlers_generic(generic_input, bundles)
 
     default = PostToolUseOutput(continue_=True)
     result = mapper.map_to_post_tool_use_output(results, default)
@@ -113,13 +121,16 @@ async def post_tool_use_hook(input_data: PostToolUseInput) -> PostToolUseOutput:
 
 
 @router.post("/UserPromptSubmit", response_model=UserPromptSubmitOutput, response_model_exclude_none=True)
-async def user_prompt_submit_hook(input_data: UserPromptSubmitInput) -> UserPromptSubmitOutput:
+async def user_prompt_submit_hook(wrapper: RequestWrapper) -> UserPromptSubmitOutput:
     """Handle UserPromptSubmit hook events."""
+    input_data = UserPromptSubmitInput(**wrapper.event)
+    bundles = wrapper.bundles
+
     logger.info(f"UserPromptSubmit hook: session {input_data.session_id}")
 
     generic_input = mapper.map_user_prompt_submit_input(input_data)
 
-    results = execute_handlers_generic(generic_input)
+    results = execute_handlers_generic(generic_input, bundles)
 
     default = UserPromptSubmitOutput(continue_=True)
     result = mapper.map_to_user_prompt_submit_output(results, default)
@@ -128,13 +139,16 @@ async def user_prompt_submit_hook(input_data: UserPromptSubmitInput) -> UserProm
 
 
 @router.post("/Stop", response_model=StopOutput, response_model_exclude_none=True)
-async def stop_hook(input_data: StopInput) -> StopOutput:
+async def stop_hook(wrapper: RequestWrapper) -> StopOutput:
     """Handle Stop hook events."""
+    input_data = StopInput(**wrapper.event)
+    bundles = wrapper.bundles
+
     logger.info(f"Stop hook: session {input_data.session_id}")
 
     generic_input = mapper.map_stop_input(input_data)
 
-    results = execute_handlers_generic(generic_input)
+    results = execute_handlers_generic(generic_input, bundles)
 
     default = StopOutput(continue_=True)
     result = mapper.map_to_stop_output(results, default)
@@ -143,13 +157,16 @@ async def stop_hook(input_data: StopInput) -> StopOutput:
 
 
 @router.post("/SubagentStop", response_model=SubagentStopOutput, response_model_exclude_none=True)
-async def subagent_stop_hook(input_data: SubagentStopInput) -> SubagentStopOutput:
+async def subagent_stop_hook(wrapper: RequestWrapper) -> SubagentStopOutput:
     """Handle SubagentStop hook events."""
+    input_data = SubagentStopInput(**wrapper.event)
+    bundles = wrapper.bundles
+
     logger.info(f"SubagentStop hook: session {input_data.session_id}")
 
     generic_input = mapper.map_subagent_stop_input(input_data)
 
-    results = execute_handlers_generic(generic_input)
+    results = execute_handlers_generic(generic_input, bundles)
 
     default = SubagentStopOutput(continue_=True)
     result = mapper.map_to_subagent_stop_output(results, default)
@@ -158,13 +175,16 @@ async def subagent_stop_hook(input_data: SubagentStopInput) -> SubagentStopOutpu
 
 
 @router.post("/Notification", response_model=NotificationOutput, response_model_exclude_none=True)
-async def notification_hook(input_data: NotificationInput) -> NotificationOutput:
+async def notification_hook(wrapper: RequestWrapper) -> NotificationOutput:
     """Handle Notification hook events."""
+    input_data = NotificationInput(**wrapper.event)
+    bundles = wrapper.bundles
+
     logger.info(f"Notification hook: session {input_data.session_id}")
 
     generic_input = mapper.map_notification_input(input_data)
 
-    results = execute_handlers_generic(generic_input)
+    results = execute_handlers_generic(generic_input, bundles)
 
     default = NotificationOutput(continue_=True)
     result = mapper.map_to_notification_output(results, default)
@@ -173,13 +193,16 @@ async def notification_hook(input_data: NotificationInput) -> NotificationOutput
 
 
 @router.post("/PreCompact", response_model=PreCompactOutput, response_model_exclude_none=True)
-async def pre_compact_hook(input_data: PreCompactInput) -> PreCompactOutput:
+async def pre_compact_hook(wrapper: RequestWrapper) -> PreCompactOutput:
     """Handle PreCompact hook events."""
+    input_data = PreCompactInput(**wrapper.event)
+    bundles = wrapper.bundles
+
     logger.info(f"PreCompact hook: session {input_data.session_id}")
 
     generic_input = mapper.map_pre_compact_input(input_data)
 
-    results = execute_handlers_generic(generic_input)
+    results = execute_handlers_generic(generic_input, bundles)
 
     default = PreCompactOutput(continue_=True)
     result = mapper.map_to_pre_compact_output(results, default)
@@ -188,13 +211,16 @@ async def pre_compact_hook(input_data: PreCompactInput) -> PreCompactOutput:
 
 
 @router.post("/SessionStart", response_model=SessionStartOutput, response_model_exclude_none=True)
-async def session_start_hook(input_data: SessionStartInput) -> SessionStartOutput:
+async def session_start_hook(wrapper: RequestWrapper) -> SessionStartOutput:
     """Handle SessionStart hook events."""
+    input_data = SessionStartInput(**wrapper.event)
+    bundles = wrapper.bundles
+
     logger.info(f"SessionStart hook: session {input_data.session_id}")
 
     generic_input = mapper.map_session_start_input(input_data)
 
-    results = execute_handlers_generic(generic_input)
+    results = execute_handlers_generic(generic_input, bundles)
 
     default = SessionStartOutput(
         continue_=True,
@@ -206,13 +232,16 @@ async def session_start_hook(input_data: SessionStartInput) -> SessionStartOutpu
 
 
 @router.post("/SessionEnd", response_model=SessionEndOutput, response_model_exclude_none=True)
-async def session_end_hook(input_data: SessionEndInput) -> SessionEndOutput:
+async def session_end_hook(wrapper: RequestWrapper) -> SessionEndOutput:
     """Handle SessionEnd hook events."""
+    input_data = SessionEndInput(**wrapper.event)
+    bundles = wrapper.bundles
+
     logger.info(f"SessionEnd hook: session {input_data.session_id}")
 
     generic_input = mapper.map_session_end_input(input_data)
 
-    results = execute_handlers_generic(generic_input)
+    results = execute_handlers_generic(generic_input, bundles)
 
     default = SessionEndOutput(continue_=True)
     result = mapper.map_to_session_end_output(results, default)

--- a/src/devleaps/policies/server/common/models.py
+++ b/src/devleaps/policies/server/common/models.py
@@ -5,6 +5,15 @@ from typing import Any, Dict, List, Optional
 from .enums import SourceClient
 
 
+@dataclass
+class BaseEvent:
+    """Base class for all hook events."""
+    session_id: str
+    source_client: SourceClient
+    workspace_roots: Optional[List[str]] = None
+    source_event: Any = None  # Original hook input data object
+
+
 class PolicyAction(str, Enum):
     """Generic policy decision actions"""
     ALLOW = "allow"
@@ -38,41 +47,33 @@ class PolicyGuidance:
 
 
 @dataclass
-class ToolUseEvent:
+class ToolUseEvent(BaseEvent):
     """
     Generic representation of tool/command execution.
     Maps from:
     - Claude Code: PreToolUse (Bash, WebFetch, MCP tools)
     - Cursor: beforeShellExecution, beforeMCPExecution
     """
-    session_id: str
-    tool_name: str  # "bash", "mcp__*", etc.
-    source_client: SourceClient
+    tool_name: str = ""  # "bash", "mcp__*", etc.
     tool_is_bash: bool = False
     tool_is_mcp: bool = False
     command: Optional[str] = None  # For bash-like tools
     parameters: Optional[Dict[str, Any]] = None  # For other tools
-    workspace_roots: Optional[List[str]] = None
-    source_event: Any = None  # Original hook input data object
 
 
 @dataclass
-class PromptSubmitEvent:
+class PromptSubmitEvent(BaseEvent):
     """
     Generic representation of user prompt submission.
     Maps from:
     - Claude Code: UserPromptSubmit
     - Cursor: beforeSubmitPrompt
     """
-    session_id: str
-    source_client: SourceClient
     prompt: Optional[str] = None
-    workspace_roots: Optional[List[str]] = None
-    source_event: Any = None  # Original hook input data object
 
 
 @dataclass
-class FileEditEvent:
+class FileEditEvent(BaseEvent):
     """
     Generic representation of file edit events (BEFORE they happen).
     Maps from:
@@ -81,31 +82,23 @@ class FileEditEvent:
 
     Policies can ALLOW or DENY file edits before they are executed.
     """
-    session_id: str
-    source_client: SourceClient
     file_path: Optional[str] = None
     operation: Optional[str] = None  # "edit", "write", etc.
-    workspace_roots: Optional[List[str]] = None
-    source_event: Any = None  # Original hook input data object
 
 
 @dataclass
-class StopEvent:
+class StopEvent(BaseEvent):
     """
     Generic representation of stop/interrupt events.
     Maps from:
     - Claude Code: Stop, SubagentStop
     - Cursor: stop
     """
-    session_id: str
-    source_client: SourceClient
     stop_type: Optional[str] = None  # "stop", "subagent_stop", etc.
-    workspace_roots: Optional[List[str]] = None
-    source_event: Any = None  # Original hook input data object
 
 
 @dataclass
-class HookEvent:
+class HookEvent(BaseEvent):
     """
     Catch-all for hooks that don't fit specific categories.
     Maps from:
@@ -113,8 +106,4 @@ class HookEvent:
     - Cursor: beforeReadFile
     - Any future hooks for that matter
     """
-    session_id: str
-    source_client: SourceClient
-    hook_type: str  # "session_start", "session_end", "notification", etc.
-    workspace_roots: Optional[List[str]] = None
-    source_event: Any = None  # Original hook input data object
+    hook_type: str = ""  # "session_start", "session_end", "notification", etc.

--- a/src/devleaps/policies/server/registry.py
+++ b/src/devleaps/policies/server/registry.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, Dict, Generator, List, Type, TypeVar, Union
+from typing import Callable, Dict, Generator, List, Optional, Set, Tuple, Type, TypeVar, Union
 
 from .common.models import PolicyDecision, PolicyGuidance
 
@@ -16,54 +16,69 @@ class HookRegistry:
     """Generic registry for hook handlers and middleware using class types as keys."""
 
     def __init__(self):
-        self.handlers: Dict[Type[InputType], List[HandlerFunction]] = {}
-        self.middleware: Dict[Type[InputType], List[MiddlewareFunction]] = {}
+        # Store handlers with their bundle association: {input_class: [(handler, bundle_name_or_none), ...]}
+        self.handlers: Dict[Type[InputType], List[Tuple[HandlerFunction, Optional[str]]]] = {}
+        self.middleware: Dict[Type[InputType], List[Tuple[MiddlewareFunction, Optional[str]]]] = {}
 
-    def register_handler(self, input_class: Type[InputType], handler: HandlerFunction):
-        """Register a handler for a specific input class type."""
+    def register_handler(self, input_class: Type[InputType], handler: HandlerFunction, bundle: Optional[str] = None):
+        """Register a handler for a specific input class type with optional bundle association."""
         if input_class not in self.handlers:
             self.handlers[input_class] = []
 
-        self.handlers[input_class].append(handler)
+        self.handlers[input_class].append((handler, bundle))
         logger.debug(
-            f"Registered handler: {handler.__name__}",
+            f"Registered handler: {handler.__name__}" + (f" (bundle: {bundle})" if bundle else ""),
             extra={
                 "input_class": input_class.__name__,
                 "handler": handler.__name__,
+                "bundle": bundle,
             }
         )
 
-    def register_middleware(self, input_class: Type[InputType], middleware: MiddlewareFunction):
-        """Register middleware for a specific input class type."""
+    def register_middleware(self, input_class: Type[InputType], middleware: MiddlewareFunction, bundle: Optional[str] = None):
+        """Register middleware for a specific input class type with optional bundle association."""
         if input_class not in self.middleware:
             self.middleware[input_class] = []
 
-        self.middleware[input_class].append(middleware)
+        self.middleware[input_class].append((middleware, bundle))
         logger.debug(
-            f"Registered middleware: {middleware.__name__}",
+            f"Registered middleware: {middleware.__name__}" + (f" (bundle: {bundle})" if bundle else ""),
             extra={
                 "input_class": input_class.__name__,
                 "middleware": middleware.__name__,
+                "bundle": bundle,
             }
         )
 
-    def get_handlers(self, input_class: Type[InputType]) -> List[HandlerFunction]:
-        """Get all handlers for a specific input class type."""
-        return self.handlers.get(input_class, [])
+    def get_handlers(self, input_class: Type[InputType], enabled_bundles: List[str] = []) -> List[HandlerFunction]:
+        """Get handlers for input class, filtered by enabled bundles. Universal policies always included."""
+        all_handlers = self.handlers.get(input_class, [])
+        enabled_set = set(enabled_bundles)
 
-    def get_middleware(self, input_class: Type[InputType]) -> List[MiddlewareFunction]:
-        """Get all middleware for a specific input class type."""
-        return self.middleware.get(input_class, [])
+        return [
+            handler for handler, bundle in all_handlers
+            if bundle is None or bundle in enabled_set
+        ]
 
-    def register_all_middleware(self, input_class: Type[InputType], middleware_list: List[MiddlewareFunction]):
-        """Register multiple middleware functions at once."""
+    def get_middleware(self, input_class: Type[InputType], enabled_bundles: List[str] = []) -> List[MiddlewareFunction]:
+        """Get middleware for input class, filtered by enabled bundles. Universal middleware always included."""
+        all_middleware = self.middleware.get(input_class, [])
+        enabled_set = set(enabled_bundles)
+
+        return [
+            mw for mw, bundle in all_middleware
+            if bundle is None or bundle in enabled_set
+        ]
+
+    def register_all_middleware(self, input_class: Type[InputType], middleware_list: List[MiddlewareFunction], bundle: Optional[str] = None):
+        """Register multiple middleware functions at once with optional bundle association."""
         for middleware in middleware_list:
-            self.register_middleware(input_class, middleware)
+            self.register_middleware(input_class, middleware, bundle)
 
-    def register_all_handlers(self, input_class: Type[InputType], handler_list: List[HandlerFunction]):
-        """Register multiple handlers at once."""
+    def register_all_handlers(self, input_class: Type[InputType], handler_list: List[HandlerFunction], bundle: Optional[str] = None):
+        """Register multiple handlers at once with optional bundle association."""
         for handler in handler_list:
-            self.register_handler(input_class, handler)
+            self.register_handler(input_class, handler, bundle)
 
 
 registry: HookRegistry = HookRegistry()

--- a/src/devleaps/policies/server/session/__init__.py
+++ b/src/devleaps/policies/server/session/__init__.py
@@ -1,0 +1,24 @@
+"""
+Session state management for policy enforcement.
+
+This module provides server-side session state storage and management
+for tracking state across multiple tool use events within a session.
+"""
+
+from devleaps.policies.server.session.state import (
+    initialize_session_state,
+    get_session_state,
+    set_session_flag,
+    get_session_flag,
+    clear_session_state,
+    list_sessions,
+)
+
+__all__ = [
+    "initialize_session_state",
+    "get_session_state",
+    "set_session_flag",
+    "get_session_flag",
+    "clear_session_state",
+    "list_sessions",
+]

--- a/src/devleaps/policies/server/session/state.py
+++ b/src/devleaps/policies/server/session/state.py
@@ -1,0 +1,125 @@
+"""
+Session state management implementation.
+
+Provides thread-safe session state storage using FastAPI's app.state.
+"""
+
+import threading
+from typing import Any, Dict, Optional, Union
+
+from devleaps.policies.server.server import app
+from devleaps.policies.server.common.models import BaseEvent
+
+
+# Thread lock for session state access
+_state_lock = threading.Lock()
+
+
+def initialize_session_state():
+    """
+    Initialize the session state storage in app.state.
+
+    Should be called once at server startup before any policies are registered.
+    """
+    if not hasattr(app.state, "sessions"):
+        app.state.sessions = {}
+
+
+def get_session_state(event: BaseEvent) -> Dict[str, Any]:
+    """
+    Get the full state dictionary for a session.
+
+    Creates an empty state dict if the session doesn't exist.
+
+    Args:
+        event: The event containing session_id
+
+    Returns:
+        Dictionary containing all state for this session
+    """
+    session_id = event.session_id
+
+    with _state_lock:
+        if not hasattr(app.state, "sessions"):
+            initialize_session_state()
+
+        if session_id not in app.state.sessions:
+            app.state.sessions[session_id] = {}
+
+        return app.state.sessions[session_id].copy()
+
+
+def set_session_flag(event: BaseEvent, key: str, value: Any) -> None:
+    """
+    Set a state flag/value for a session.
+
+    Args:
+        event: The event containing session_id
+        key: The state key to set
+        value: The value to store (can be any JSON-serializable type)
+    """
+    session_id = event.session_id
+
+    with _state_lock:
+        if not hasattr(app.state, "sessions"):
+            initialize_session_state()
+
+        if session_id not in app.state.sessions:
+            app.state.sessions[session_id] = {}
+
+        app.state.sessions[session_id][key] = value
+
+
+def get_session_flag(event: BaseEvent, key: str, default: Any = None) -> Any:
+    """
+    Get a state flag/value for a session.
+
+    Args:
+        event: The event containing session_id
+        key: The state key to get
+        default: Default value if key doesn't exist
+
+    Returns:
+        The value stored for this key, or default if not found
+    """
+    session_id = event.session_id
+
+    with _state_lock:
+        if not hasattr(app.state, "sessions"):
+            initialize_session_state()
+
+        if session_id not in app.state.sessions:
+            return default
+
+        return app.state.sessions[session_id].get(key, default)
+
+
+def clear_session_state(event: BaseEvent) -> None:
+    """
+    Clear all state for a session.
+
+    Args:
+        event: The event containing session_id to clear
+    """
+    session_id = event.session_id
+
+    with _state_lock:
+        if not hasattr(app.state, "sessions"):
+            initialize_session_state()
+
+        if session_id in app.state.sessions:
+            del app.state.sessions[session_id]
+
+
+def list_sessions() -> list[str]:
+    """
+    List all active session IDs.
+
+    Returns:
+        List of session IDs that have state stored
+    """
+    with _state_lock:
+        if not hasattr(app.state, "sessions"):
+            initialize_session_state()
+
+        return list(app.state.sessions.keys())


### PR DESCRIPTION
Closes #4 

This adds "bundles", bundles group policies together which clients can opt in to.

Universal policies (those with no bundles) always run. The client also includes a new option, `--bundle` which makes the client request the activation of those policies.

For example you might have a project in which you use `uv` and instead of interacting with `pip` or `python`:

https://github.com/Devleaps/agent-policies/blob/6e7c071a19452f6380d9b2e035c0e14ddbdbf97c/src/devleaps/policies/example/main.py#L48-L68

But not all your projects might be using `uv`, which would make this policy complicated for regular Python projects. With the new feature, you can put the `uv` policies under a bundle, like so:

https://github.com/Devleaps/agent-policies/blob/6e7c071a19452f6380d9b2e035c0e14ddbdbf97c/src/devleaps/policies/example/main.py#L78

And run the client with `--bundle uv` to enable that rule. You can add as many rules and middleware as you like on one bundle.

---

In addition, this PR adds a small wrapper around FastAPI's session mechanism. Events from Claude Code and Cursor both have a session-id, this is used more or less as a session cookie. That way, you can make policies that enable only when certain actions have or have not occurred for earlier steps. As a simple example, one could make a policy that disallows git commit without first running tests.