### PR TITLE
feat: Config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Add `devleaps-policy-client` to your Claude Code hooks configuration in `~/.clau
           {
             "matcher": "*",
             "type": "command",
-            "command": "devleaps-policy-client claude-code"
+            "command": "devleaps-policy-client"
           }
         ]
       }
@@ -119,7 +119,7 @@ Add `devleaps-policy-client` to your Claude Code hooks configuration in `~/.clau
           {
             "matcher": "*",
             "type": "command",
-            "command": "devleaps-policy-client claude-code"
+            "command": "devleaps-policy-client"
           }
         ]
       }
@@ -130,7 +130,7 @@ Add `devleaps-policy-client` to your Claude Code hooks configuration in `~/.clau
           {
             "matcher": "*",
             "type": "command",
-            "command": "devleaps-policy-client claude-code"
+            "command": "devleaps-policy-client"
           }
         ]
       }
@@ -141,7 +141,7 @@ Add `devleaps-policy-client` to your Claude Code hooks configuration in `~/.clau
           {
             "matcher": "*",
             "type": "command",
-            "command": "devleaps-policy-client claude-code"
+            "command": "devleaps-policy-client"
           }
         ]
       }
@@ -152,7 +152,7 @@ Add `devleaps-policy-client` to your Claude Code hooks configuration in `~/.clau
           {
             "matcher": "*",
             "type": "command",
-            "command": "devleaps-policy-client claude-code"
+            "command": "devleaps-policy-client"
           }
         ]
       }
@@ -163,7 +163,7 @@ Add `devleaps-policy-client` to your Claude Code hooks configuration in `~/.clau
           {
             "matcher": "*",
             "type": "command",
-            "command": "devleaps-policy-client claude-code"
+            "command": "devleaps-policy-client"
           }
         ]
       }
@@ -174,7 +174,7 @@ Add `devleaps-policy-client` to your Claude Code hooks configuration in `~/.clau
           {
             "matcher": "*",
             "type": "command",
-            "command": "devleaps-policy-client claude-code"
+            "command": "devleaps-policy-client"
           }
         ]
       }
@@ -185,7 +185,7 @@ Add `devleaps-policy-client` to your Claude Code hooks configuration in `~/.clau
           {
             "matcher": "*",
             "type": "command",
-            "command": "devleaps-policy-client claude-code"
+            "command": "devleaps-policy-client"
           }
         ]
       }
@@ -196,7 +196,7 @@ Add `devleaps-policy-client` to your Claude Code hooks configuration in `~/.clau
           {
             "matcher": "*",
             "type": "command",
-            "command": "devleaps-policy-client claude-code"
+            "command": "devleaps-policy-client"
           }
         ]
       }
@@ -219,28 +219,28 @@ Create or edit `~/.cursor/hooks.json`:
   "version": 1,
   "hooks": {
     "beforeShellExecution": [
-      { "command": "devleaps-policy-client cursor" }
+      { "command": "devleaps-policy-client" }
     ],
     "beforeMCPExecution": [
-      { "command": "devleaps-policy-client cursor" }
+      { "command": "devleaps-policy-client" }
     ],
     "afterFileEdit": [
-      { "command": "devleaps-policy-client cursor" }
+      { "command": "devleaps-policy-client" }
     ],
     "beforeReadFile": [
-      { "command": "devleaps-policy-client cursor" }
+      { "command": "devleaps-policy-client" }
     ],
     "beforeSubmitPrompt": [
-      { "command": "devleaps-policy-client cursor" }
+      { "command": "devleaps-policy-client" }
     ],
     "stop": [
-      { "command": "devleaps-policy-client cursor" }
+      { "command": "devleaps-policy-client" }
     ]
   }
 }
 ```
 
-The `devleaps-policy-client cursor` command will forward hook events to the policy server running on `localhost:8338`.
+The `devleaps-policy-client` command will forward hook events to the policy server running on `localhost:8338`.
 
 </details>
 
@@ -248,14 +248,41 @@ The `devleaps-policy-client cursor` command will forward hook events to the poli
 
 Each Claude Code or Cursor session receives a unique `session_id`. Policies can use this to track context across multiple hook events within the same session, enabling stateful policy decisions. See the [session state utility](devleaps/policies/server/session/state.py) to store and retrieve per-session data.
 
+## Configuration
+
+The client supports centralized configuration via JSON files:
+
+**Home-level config** (`~/.agent-policies/config.json`):
+```json
+{
+  "bundles": ["python", "git"],
+  "editor": "claude-code",
+  "server_url": "http://localhost:8338"
+}
+```
+
+**Project-level config** (`.agent-policies/config.json`):
+```json
+{
+  "bundles": ["terraform"]
+}
+```
+
+Configuration is merged with project settings overriding home settings.
+
+**Available fields:**
+- `bundles`: List of enabled policy bundles (default: `[]`)
+- `editor`: Editor name, ignored by client (default: `claude-code`)
+- `server_url`: Policy server endpoint (default: `http://localhost:8338`)
+
 ## Policy Bundles
 
 Policies can be organized into bundles to group related rules for specific workflows or project types. This allows you to compose different policy sets without having to manage separate server configurations.
 
 **How bundles work:**
 - Universal policies (registered with `bundle=None`) are always enforced
-- Bundle-specific policies are only enforced when enabled via `--bundle` flag
-- Multiple bundles can be enabled simultaneously: `devleaps-policy-client --bundle uv claude-code`
+- Bundle-specific policies are only enforced when enabled in config
+- Multiple bundles can be enabled: set `"bundles": ["bundle1", "bundle2"]` in config
 - Bundles can coordinate through shared session state
 
 See the [uv example](devleaps/policies/example/main.py) for a working one-rule bundle implementation.

--- a/src/devleaps/policies/client/client.py
+++ b/src/devleaps/policies/client/client.py
@@ -1,42 +1,33 @@
 #!/usr/bin/env python3
-import argparse
 import json
-import os
 import sys
 from typing import Any, Dict, List
 
 import requests
 
-DEFAULT_SERVER_URL = "http://localhost:8338"
-TIMEOUT_SECONDS = 30
-
-
-def get_server_url() -> str:
-    return os.environ.get("HOOK_SERVER_URL", DEFAULT_SERVER_URL)
+from devleaps.policies.client.config import ConfigManager
 
 
 def forward_hook(editor: str, bundles: List[str], payload: Dict[str, Any]) -> int:
-    server_url = get_server_url()
+    config = ConfigManager.load_config()
+    server_url = ConfigManager.get_server_url(config)
     hook_event_name = payload.get("hook_event_name")
 
     if not hook_event_name:
         print("Missing hook_event_name in payload", file=sys.stderr)
         return 2
 
-    # Wrap payload with bundles
     wrapped_payload = {
         "bundles": bundles,
         "event": payload
     }
 
-    # Direct path mapping: /policy/{editor}/{hook_event_name}
     endpoint = f"/policy/{editor}/{hook_event_name}"
 
     try:
         response = requests.post(
             f"{server_url}{endpoint}",
-            json=wrapped_payload,
-            timeout=TIMEOUT_SECONDS
+            json=wrapped_payload
         )
 
         if response.status_code != 200:
@@ -52,13 +43,7 @@ def forward_hook(editor: str, bundles: List[str], payload: Dict[str, Any]) -> in
         print(f"Error: Cannot connect to policy server at {server_url}", file=sys.stderr)
         print("", file=sys.stderr)
         print("To start the server, run: devleaps-policy-server", file=sys.stderr)
-        print(f"Or set HOOK_SERVER_URL environment variable to point to your server", file=sys.stderr)
-        return 2
-    except requests.exceptions.Timeout:
-        print(f"Error: Policy server timeout after {TIMEOUT_SECONDS} seconds", file=sys.stderr)
-        print(f"Server: {server_url}", file=sys.stderr)
-        print("", file=sys.stderr)
-        print("The server may be overloaded or the policy evaluation is taking too long.", file=sys.stderr)
+        print(f"Or configure server_url in ~/.agent-policies/config.json", file=sys.stderr)
         return 2
     except Exception as e:
         print(f"Error: Unexpected failure communicating with policy server", file=sys.stderr)
@@ -68,27 +53,14 @@ def forward_hook(editor: str, bundles: List[str], payload: Dict[str, Any]) -> in
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Policy client for AI agent hooks"
-    )
-    parser.add_argument(
-        "--bundle",
-        action="append",
-        dest="bundles",
-        default=[],
-        help="Enable a policy bundle (can be specified multiple times)"
-    )
-    parser.add_argument(
-        "editor",
-        help="Editor name (e.g., claude-code or cursor)"
-    )
-
-    args = parser.parse_args()
+    config = ConfigManager.load_config()
+    editor = ConfigManager.get_editor(config)
+    bundles = ConfigManager.get_enabled_bundles(config)
 
     try:
         hook_json = sys.stdin.read().strip()
         payload = json.loads(hook_json)
-        exit_code = forward_hook(args.editor, args.bundles, payload)
+        exit_code = forward_hook(editor, bundles, payload)
         sys.exit(exit_code)
     except json.JSONDecodeError as e:
         print(f"Invalid JSON in hook payload: {e}", file=sys.stderr)

--- a/src/devleaps/policies/client/config.py
+++ b/src/devleaps/policies/client/config.py
@@ -1,0 +1,105 @@
+"""
+Configuration system for agent policies.
+
+Supports loading configuration from:
+1. User home directory: ~/.agent-policies/config.json
+2. Project directory: .agent-policies/config.json
+
+Configurations are merged with project-level settings taking precedence over home-level.
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+class ConfigManager:
+    """Manages configuration loading and merging from multiple levels."""
+
+    DEFAULT_CONFIG = {
+        "bundles": [],
+        "editor": "claude-code",
+        "server_url": "http://localhost:8338",
+    }
+
+    @staticmethod
+    def _load_config_file(path: Path) -> Dict[str, Any]:
+        """Load a single configuration file, return empty dict if not found."""
+        if not path.exists():
+            return {}
+
+        try:
+            with open(path, "r") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError) as e:
+            print(f"Warning: Failed to load config from {path}: {e}")
+            return {}
+
+    @staticmethod
+    def _merge_configs(home_config: Dict[str, Any], project_config: Dict[str, Any]) -> Dict[str, Any]:
+        """Merge home and project configs, with project taking precedence."""
+        merged = ConfigManager.DEFAULT_CONFIG.copy()
+
+        # Merge home config
+        merged.update(home_config)
+
+        # Merge project config (overrides home config)
+        merged.update(project_config)
+
+        return merged
+
+    @classmethod
+    def load_config(cls, project_root: Optional[str] = None) -> Dict[str, Any]:
+        """
+        Load and merge configuration from home and project directories.
+
+        Args:
+            project_root: Root directory of the project. If None, uses current directory.
+
+        Returns:
+            Merged configuration dictionary.
+        """
+        if project_root is None:
+            project_root = os.getcwd()
+
+        # Load home directory config
+        home_config_path = Path.home() / ".agent-policies" / "config.json"
+        home_config = cls._load_config_file(home_config_path)
+
+        # Load project directory config
+        project_config_path = Path(project_root) / ".agent-policies" / "config.json"
+        project_config = cls._load_config_file(project_config_path)
+
+        # Merge and return
+        return cls._merge_configs(home_config, project_config)
+
+    @staticmethod
+    def get_enabled_bundles(config: Optional[Dict[str, Any]] = None) -> list:
+        """Get list of enabled bundles from config."""
+        if config is None:
+            config = ConfigManager.load_config()
+        return config.get("bundles", [])
+
+    @staticmethod
+    def get_editor(config: Optional[Dict[str, Any]] = None) -> Optional[str]:
+        """Get editor preference from config."""
+        if config is None:
+            config = ConfigManager.load_config()
+        return config.get("editor")
+
+    @staticmethod
+    def get_server_url(config: Optional[Dict[str, Any]] = None) -> str:
+        """Get server URL from config."""
+        if config is None:
+            config = ConfigManager.load_config()
+        return config.get("server_url", "http://localhost:8338")
+
+    @staticmethod
+    def ensure_config_directories() -> None:
+        """Ensure configuration directories exist."""
+        home_config_dir = Path.home() / ".agent-policies"
+        home_config_dir.mkdir(parents=True, exist_ok=True)
+
+        project_config_dir = Path.cwd() / ".agent-policies"
+        project_config_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,80 @@
+"""Tests for the policy client."""
+
+import json
+from unittest import mock
+
+from devleaps.policies.client.client import forward_hook
+from devleaps.policies.client.config import ConfigManager
+
+
+def test_forward_hook_successful_response(capsys):
+    """forward_hook returns 0 on success and prints response."""
+    payload = {"hook_event_name": "PreToolUse", "tool_name": "bash"}
+    expected_response = {"continue_": True}
+
+    with mock.patch("devleaps.policies.client.client.requests.post") as mock_post:
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = expected_response
+        mock_post.return_value = mock_response
+
+        result = forward_hook("claude-code", ["python-quality"], payload)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert json.dumps(expected_response) in captured.out
+
+
+def test_forward_hook_sends_correct_payload():
+    """forward_hook sends bundles and event in payload."""
+    payload = {"hook_event_name": "PreToolUse", "tool_name": "bash"}
+    bundles = ["python-quality", "git-workflow"]
+
+    with mock.patch("devleaps.policies.client.client.requests.post") as mock_post:
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"continue_": True}
+        mock_post.return_value = mock_response
+
+        forward_hook("claude-code", bundles, payload)
+
+        call_args = mock_post.call_args
+        sent_payload = call_args[1]["json"]
+        assert sent_payload["bundles"] == bundles
+        assert sent_payload["event"] == payload
+
+
+def test_forward_hook_posts_to_correct_endpoint():
+    """forward_hook posts to correct editor and event endpoint."""
+    payload = {"hook_event_name": "PreToolUse", "tool_name": "bash"}
+
+    with mock.patch("devleaps.policies.client.client.requests.post") as mock_post:
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"continue_": True}
+        mock_post.return_value = mock_response
+
+        forward_hook("claude-code", [], payload)
+
+        call_args = mock_post.call_args
+        url = call_args[0][0]
+        assert "/policy/claude-code/PreToolUse" in url
+
+
+def test_forward_hook_multiple_bundles(capsys):
+    """forward_hook works with multiple enabled bundles."""
+    payload = {"hook_event_name": "PreToolUse", "tool_name": "bash"}
+    bundles = ["python-quality", "git-workflow"]
+
+    with mock.patch("devleaps.policies.client.client.requests.post") as mock_post:
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"continue_": True, "reason": "allowed"}
+        mock_post.return_value = mock_response
+
+        result = forward_hook("claude-code", bundles, payload)
+
+        assert result == 0
+        call_args = mock_post.call_args
+        sent_payload = call_args[1]["json"]
+        assert len(sent_payload["bundles"]) == 2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,46 @@
+"""Tests for configuration system."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from devleaps.policies.client.config import ConfigManager
+
+
+def test_load_valid_config_file():
+    """Loading a valid config file returns parsed JSON."""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        config = {"bundles": ["python-quality"], "editor": "cursor"}
+        json.dump(config, f)
+        f.flush()
+
+        try:
+            result = ConfigManager._load_config_file(Path(f.name))
+            assert result == config
+        finally:
+            os.unlink(f.name)
+
+
+def test_merge_project_overrides_home():
+    """Project config takes precedence over home config."""
+    home_config = {"bundles": ["python-quality"], "editor": "vscode"}
+    project_config = {"bundles": ["git-workflow"], "editor": "cursor"}
+    result = ConfigManager._merge_configs(home_config, project_config)
+    assert result["bundles"] == ["git-workflow"]
+    assert result["editor"] == "cursor"
+
+
+def test_get_enabled_bundles():
+    """get_enabled_bundles returns bundles from config."""
+    config = {"bundles": ["python-quality", "git-workflow"]}
+    result = ConfigManager.get_enabled_bundles(config)
+    assert result == ["python-quality", "git-workflow"]
+
+
+def test_get_editor():
+    """get_editor returns editor preference from config."""
+    config = {"editor": "cursor"}
+    result = ConfigManager.get_editor(config)
+    assert result == "cursor"


### PR DESCRIPTION
This allows one to have a global config file and a per-project config file (Similar to how `.gitignore` works).

From README.md:

The client supports ce

> Centralized configuration via JSON files:
> 
> **Home-level config** (`~/.agent-policies/config.json`):
> ```json
> {
>   "bundles": ["python", "git"],
>   "editor": "claude-code",
>   "server_url": "http://localhost:8338"
> }
> ```
> 
> **Project-level config** (`.agent-policies/config.json`):
> ```json
> {
>   "bundles": ["terraform"]
> }
> ```
> 
> Configuration is merged with project settings overriding home settings.
